### PR TITLE
Add support for ISO-15118-2 Plug And Charge

### DIFF
--- a/exi-15118/src/net-exi.rs
+++ b/exi-15118/src/net-exi.rs
@@ -263,6 +263,12 @@ impl IsoNetConfig {
                         {
                             jsonc.add("challenge", &base64_encode(session.challenge.as_ref()))?;
                         }
+                    },
+                    MessageTagId::MeteringReceiptReq => {
+                        // Ass the session id if not present
+                        if jsonc.optional::<String>("session")?.is_none() {
+                            jsonc.add("session", &bytes_to_hexa(&session.session_id))?;
+                        }
                     }
                     _ => {}
                 }

--- a/exi-15118/src/net-exi.rs
+++ b/exi-15118/src/net-exi.rs
@@ -238,6 +238,7 @@ impl IsoNetConfig {
         session: &IsoSessionState,
         msg_id: u32,
         jsonc: JsoncObj,
+        pki_conf: Option<&'static PkiConfig>,
     ) -> Result<IsoMsgResId, AfbError> {
         // extract message id from json
 
@@ -344,6 +345,9 @@ impl IsoNetConfig {
                 match &body {
                     MessageBody::SessionSetupRes(_msg) => {
                         session.session_id = header.get_session_id().to_vec()
+                    }
+                    MessageBody::PaymentDetailsRes(msg) => {
+                        session.challenge = msg.get_challenge().to_vec();
                     }
                     MessageBody::PaymentDetailsReq(msg) => {
                         // extract certificate and check it match with ca_trust root list

--- a/exi-15118/src/net-exi.rs
+++ b/exi-15118/src/net-exi.rs
@@ -150,9 +150,6 @@ impl IsoNetConfig {
         msg_id: u32,
         jbody: JsoncObj,
     ) -> Result<IsoMsgResId, AfbError> {
-
-
-
         // move tcp socket data into exi stream buffer
         let mut lock = self.stream.lock_stream();
 
@@ -173,8 +170,18 @@ impl IsoNetConfig {
     ) -> Result<(), AfbError> {
         use iso2_exi::*;
 
+        let null_session = vec![0 as u8];
+
+        let session_id = {
+            if session.session_id.len() == 0 {
+                &null_session
+            } else {
+                &session.session_id
+            }
+        };
+
         // build exi payload from json
-        let header = ExiMessageHeader::new(&session.session_id)?;
+        let header = ExiMessageHeader::new(session_id)?;
 
         let mut exi_doc = ExiMessageDoc::new(&header, &body);
         if let Some(pki) = self.pki_conf {

--- a/jsonc-15118/Cargo.toml
+++ b/jsonc-15118/Cargo.toml
@@ -9,6 +9,7 @@ build = "etc/build.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json={ version= "1.0"}
+base64 = {version = "0.22.1"}
 nettls= {git= "https://github.com/tux-evse/iso15118-network-rs.git", branch="main", default-features = false, optional = true}
 iso15118= {git= "https://github.com/tux-evse/iso15118-encoders-rs.git", branch="main", default-features = false, optional = true}
 

--- a/jsonc-15118/Cargo.toml
+++ b/jsonc-15118/Cargo.toml
@@ -9,7 +9,6 @@ build = "etc/build.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json={ version= "1.0"}
-base64 = {version = "0.22.1"}
 nettls= {git= "https://github.com/tux-evse/iso15118-network-rs.git", branch="main", default-features = false, optional = true}
 iso15118= {git= "https://github.com/tux-evse/iso15118-encoders-rs.git", branch="main", default-features = false, optional = true}
 

--- a/jsonc-15118/src/@lib-jsonc.rs
+++ b/jsonc-15118/src/@lib-jsonc.rs
@@ -31,8 +31,8 @@ pub mod din_jsonc;
 pub mod iso2_jsonc;
 
 pub mod prelude {
-    pub use crate::{IsoToJson, ApiMsgInfo};
-    pub use crate::sdp_jsonc::sdp_jsonc;
     pub use crate::din_jsonc::din_jsonc;
     pub use crate::iso2_jsonc::iso2_jsonc;
+    pub use crate::sdp_jsonc::sdp_jsonc;
+    pub use crate::{ApiMsgInfo, IsoToJson};
 }

--- a/jsonc-15118/src/@lib-jsonc.rs
+++ b/jsonc-15118/src/@lib-jsonc.rs
@@ -7,9 +7,17 @@
 extern crate afbv4;
 
 use afbv4::prelude::*;
+
+use iso15118::prelude::PkiConfig;
 pub trait IsoToJson {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError>;
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError>;
+    fn from_jsonc_and_pki(
+        jsonc: JsoncObj,
+        pki_conf: &'static PkiConfig,
+    ) -> Result<Box<Self>, AfbError> {
+        Self::from_jsonc(jsonc)
+    }
 }
 
 pub struct ApiMsgInfo {

--- a/jsonc-15118/src/iso2-jsonc/authorization.rs
+++ b/jsonc-15118/src/iso2-jsonc/authorization.rs
@@ -10,10 +10,10 @@
  *
  */
 
+use crate::prelude::iso2_jsonc::base64_decode;
 use crate::prelude::*;
 use afbv4::prelude::*;
 use iso15118::prelude::iso2_exi::*;
-
 
 impl IsoToJson for AuthorizationRequest {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError> {
@@ -33,8 +33,8 @@ impl IsoToJson for AuthorizationRequest {
             payload.set_id(value)?;
         }
 
-        if let Some(base64) = jsonc.optional::<Vec<u8>>("challenge")? {
-           payload.set_challenge(&base64)?;
+        if let Some(base64) = jsonc.optional::<&str>("challenge")? {
+            payload.set_challenge(&base64_decode(base64)?)?;
         }
 
         Ok(Box::new(payload))

--- a/jsonc-15118/src/iso2-jsonc/authorization.rs
+++ b/jsonc-15118/src/iso2-jsonc/authorization.rs
@@ -27,10 +27,10 @@ impl IsoToJson for AuthorizationRequest {
         Ok(jsonc)
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
-        let mut payload= AuthorizationRequest::new();
+        let mut payload = AuthorizationRequest::new();
 
         if let Some(value) = jsonc.optional("id")? {
-           payload.set_id(value)?;
+            payload.set_id(value)?;
         }
 
         if let Some(base64) = jsonc.optional::<Vec<u8>>("challenge")? {
@@ -50,8 +50,8 @@ impl IsoToJson for AuthorizationResponse {
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
         let rcode = ResponseCode::from_label(jsonc.get("rcode")?)?;
-        let processing= EvseProcessing::from_label(jsonc.get("processing")?)?;
-        let payload= AuthorizationResponse::new(rcode, processing);
+        let processing = EvseProcessing::from_label(jsonc.get("processing")?)?;
+        let payload = AuthorizationResponse::new(rcode, processing);
         Ok(Box::new(payload))
     }
 }

--- a/jsonc-15118/src/iso2-jsonc/encoders-lib.rs
+++ b/jsonc-15118/src/iso2-jsonc/encoders-lib.rs
@@ -35,8 +35,8 @@ mod authorization;
 #[path = "cable-check.rs"]
 mod cable_check;
 
-#[path ="certificate-install.rs"]
-mod certificate_install ;
+#[path = "certificate-install.rs"]
+mod certificate_install;
 
 #[path = "certificate-update.rs"]
 mod certificate_update;

--- a/jsonc-15118/src/iso2-jsonc/encoders-lib.rs
+++ b/jsonc-15118/src/iso2-jsonc/encoders-lib.rs
@@ -10,7 +10,6 @@
  *
  */
 
-
 #[cfg(not(afbv4))]
 extern crate afbv4;
 
@@ -76,8 +75,22 @@ mod welding_detection;
 pub mod encoders_test;
 
 pub mod iso2_jsonc {
-    pub use super::sub_types::*;
+    use iso15118::prelude::{AfbError, GnuPkiDatum};
+    pub fn base64_decode(base64: &str) -> Result<Vec<u8>, AfbError> {
+        GnuPkiDatum::new(base64.as_bytes())
+            .b64decode()
+            .map(|x| x.to_vec())
+    }
+
+    pub fn base64_encode(data: &[u8]) -> String {
+        GnuPkiDatum::new(data)
+            .b64encode()
+            .unwrap()
+            .to_string()
+            .unwrap()
+    }
     pub use super::authorization::*;
+    pub use super::body_encoder::*;
     pub use super::cable_check::*;
     pub use super::certificate_install::*;
     pub use super::certificate_update::*;
@@ -93,6 +106,6 @@ pub mod iso2_jsonc {
     pub use super::service_discovery::*;
     pub use super::session_setup::*;
     pub use super::session_stop::*;
+    pub use super::sub_types::*;
     pub use super::welding_detection::*;
-    pub use super::body_encoder::*;
 }

--- a/jsonc-15118/src/iso2-jsonc/metering-receipt.rs
+++ b/jsonc-15118/src/iso2-jsonc/metering-receipt.rs
@@ -28,7 +28,7 @@ impl IsoToJson for MeteringReceiptRequest {
         Ok(jsonc)
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
-        let mut buffer= [0x00; 6];
+        let mut buffer= [0x00; 8];
         let session_id = hexa_to_bytes(jsonc.get("session")?, &mut buffer)?;
         let meter_info = MeterInfo::from_jsonc(jsonc.get("info")?)?;
         let mut payload= MeteringReceiptRequest::new(session_id, &meter_info)?;

--- a/jsonc-15118/src/iso2-jsonc/payment-details.rs
+++ b/jsonc-15118/src/iso2-jsonc/payment-details.rs
@@ -31,9 +31,10 @@ impl IsoToJson for PaymentDetailsRequest {
 
 impl IsoToJson for PaymentDetailsResponse {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError> {
+        use iso2_jsonc::base64_encode;
         let jsonc = JsoncObj::new();
         jsonc.add("rcode", self.get_rcode().to_label())?;
-        jsonc.add("challenge", self.get_challenge())?;
+        jsonc.add("challenge", &base64_encode(self.get_challenge()))?;
         jsonc.add("timestamp", self.get_time_stamp())?;
         Ok(jsonc)
     }

--- a/jsonc-15118/src/iso2-jsonc/payment-details.rs
+++ b/jsonc-15118/src/iso2-jsonc/payment-details.rs
@@ -18,13 +18,13 @@ impl IsoToJson for PaymentDetailsRequest {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError> {
         let jsonc = JsoncObj::new();
         jsonc.add("emaid", self.get_emaid()?)?;
-        jsonc.add("chain",self.get_contract_chain().to_jsonc()?)?;
+        jsonc.add("chain", self.get_contract_chain().to_jsonc()?)?;
         Ok(jsonc)
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
-        let contract= CertificateChainType::from_jsonc(jsonc.get("chain")?)?;
-        let emaid= jsonc.get("emaid")?;
-        let payload= PaymentDetailsRequest::new(emaid, contract.as_ref())?;
+        let contract = CertificateChainType::from_jsonc(jsonc.get("chain")?)?;
+        let emaid = jsonc.get("emaid")?;
+        let payload = PaymentDetailsRequest::new(emaid, contract.as_ref())?;
         Ok(Box::new(payload))
     }
 }
@@ -39,9 +39,9 @@ impl IsoToJson for PaymentDetailsResponse {
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
         let rcode = ResponseCode::from_label(jsonc.get("rcode")?)?;
-        let challenge= jsonc.get::<&str>("challenge")?;
+        let challenge = jsonc.get::<&str>("challenge")?;
 
-        let payload= PaymentDetailsResponse::new(rcode, challenge.as_bytes())?;
+        let payload = PaymentDetailsResponse::new(rcode, challenge.as_bytes())?;
         Ok(Box::new(payload))
     }
 }

--- a/jsonc-15118/src/iso2-jsonc/sub-types.rs
+++ b/jsonc-15118/src/iso2-jsonc/sub-types.rs
@@ -12,18 +12,14 @@
 
 use crate::prelude::*;
 use afbv4::prelude::*;
-use iso15118::prelude::iso2_exi::*;
+use iso15118::prelude::{iso2_exi::*, GnuPkiDatum};
 
 fn base64_decode(base64: &str) -> Result<Vec<u8>, AfbError> {
-    use base64::prelude::*;
-    BASE64_STANDARD
-        .decode(base64)
-        .or_else(|_| afb_error!("base64-decode", "Malformed base64 string"))
+    GnuPkiDatum::new(base64.as_bytes()).b64decode().map(|x| x.to_vec())
 }
 
 fn base64_encode(data: &[u8]) -> String {
-    use base64::prelude::*;
-    BASE64_STANDARD.encode(data)
+    GnuPkiDatum::new(data).b64encode().unwrap().to_string().unwrap()
 }
 
 impl IsoToJson for EmaidType {

--- a/jsonc-15118/src/iso2-jsonc/sub-types.rs
+++ b/jsonc-15118/src/iso2-jsonc/sub-types.rs
@@ -316,12 +316,12 @@ impl IsoToJson for DcEvseChargeParam {
         )?;
 
         if let Some(jvalue) = jsonc.optional("regul_tolerance")? {
-            let value= PhysicalValue::from_jsonc(jvalue)?;
+            let value = PhysicalValue::from_jsonc(jvalue)?;
             payload.set_regul_tolerance(&value)?;
         }
 
         if let Some(jvalue) = jsonc.optional("energy_to_deliver")? {
-            let value= PhysicalValue::from_jsonc(jvalue)?;
+            let value = PhysicalValue::from_jsonc(jvalue)?;
             payload.set_energy_to_deliver(&value)?;
         }
 

--- a/jsonc-15118/src/iso2-jsonc/sub-types.rs
+++ b/jsonc-15118/src/iso2-jsonc/sub-types.rs
@@ -14,14 +14,6 @@ use crate::prelude::*;
 use afbv4::prelude::*;
 use iso15118::prelude::{iso2_exi::*, GnuPkiDatum};
 
-fn base64_decode(base64: &str) -> Result<Vec<u8>, AfbError> {
-    GnuPkiDatum::new(base64.as_bytes()).b64decode().map(|x| x.to_vec())
-}
-
-fn base64_encode(data: &[u8]) -> String {
-    GnuPkiDatum::new(data).b64encode().unwrap().to_string().unwrap()
-}
-
 impl IsoToJson for EmaidType {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError> {
         let jsonc = JsoncObj::new();
@@ -114,6 +106,7 @@ impl IsoToJson for CertificateRootList {
 
 impl IsoToJson for CertificateChainType {
     fn to_jsonc(&self) -> Result<JsoncObj, AfbError> {
+        use crate::prelude::iso2_jsonc::base64_encode;
         let jsonc = JsoncObj::new();
         if let Some(value) = self.get_id() {
             jsonc.add("id", value)?;
@@ -131,6 +124,7 @@ impl IsoToJson for CertificateChainType {
         Ok(jsonc)
     }
     fn from_jsonc(jsonc: JsoncObj) -> Result<Box<Self>, AfbError> {
+        use crate::prelude::iso2_jsonc::base64_decode;
         let cert_data = base64_decode(&jsonc.get::<String>("cert")?)?;
         let mut cert_chain = CertificateChainType::new(&cert_data)?;
 


### PR DESCRIPTION
This PR adds support for Plug And Charge for ISO-15118-2.
It depends on:
- https://github.com/tux-evse/iso15118-encoders-rs/pull/2
- https://github.com/tux-evse/iso15118-encoders/pull/2
